### PR TITLE
[rabbitmq] Fix a bug which caused MT Operator to not work on newly created clusters

### DIFF
--- a/charts/rabbitmq/templates/admin.yaml
+++ b/charts/rabbitmq/templates/admin.yaml
@@ -1,4 +1,5 @@
 # Copyright 2021-2022 Telematics Technologies sp. z o.o.
+# Copyright 2022 Krzysztof Wencel
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,25 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if not .Values.rabbitmq.definitions }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-default-user-credentials
-type: Opaque
-data:
-  username: {{ .Values.auth.username | b64enc }}
-  password: {{ .Values.auth.password | b64enc }}
----
-apiVersion: rabbitmq.com/v1beta1
-kind: User
-metadata:
   name: {{ .Release.Name }}-default-user
-spec:
-  tags:
-    - administrator
-  rabbitmqClusterReference:
-    name: {{ .Release.Name }}
-  importCredentialsSecret:
-    name: {{ .Release.Name }}-default-user-credentials
-{{- end }}
+stringData:
+  default_user.conf: |
+    default_user = {{ .Values.auth.username }}
+    default_pass = {{ .Values.auth.password }}
+  username: {{ .Values.auth.username }}
+  password: {{ .Values.auth.password }}

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -52,8 +52,6 @@ rabbitmq:
     disk_free_limit.absolute = 512MiB
     log.file.level = debug
     default_vhost = {{ .Values.rabbitmq.defaultVhost }}
-    default_user = {{ .Values.auth.username }}
-    default_pass = {{ .Values.auth.password }}
 #  additionalConfig: |
 #    log.file.level = info
 #  additionalPlugins:


### PR DESCRIPTION
## Describe your changes

This pull request fixes a problem when Messaging Topology Operator could not communicate on a newly create clusters.
Additionally, compatibility of MT Operator with clusters using `definitions.json` file has been improved.

More info:
https://github.com/rabbitmq/messaging-topology-operator/discussions/300
https://github.com/rabbitmq/messaging-topology-operator/issues/365

## Legal
Please confirm the following:

- [x] I agree to submit all of my contributions contained in this pull request under the terms of the [Apache License, Version 2.0](../LICENSE) and have read this licence.
- [x] I have added and/or updated the copyright notices and/or licencing information in the relevant file headers (see: [CONTRIBUTING.md](../charts/rabbitmq/CONTRIBUTING.md#licence-and-copyright-headers)).
